### PR TITLE
Limit `wcmp_visitors_stats.user_cookie` index length to 191 chars

### DIFF
--- a/includes/class-wcmp-install.php
+++ b/includes/class-wcmp-install.php
@@ -238,7 +238,7 @@ class WCMp_Install {
                 CONSTRAINT visitor UNIQUE (vendor_id, session_id),
                 KEY vendor_id (vendor_id),
                 KEY user_id (user_id),
-                KEY user_cookie (user_cookie),
+                KEY user_cookie (user_cookie(191)),
                 KEY session_id (session_id),
                 KEY ip (ip)
 		) $collate;";


### PR DESCRIPTION
MySQL limits indexes to 767 bytes. Since WordPress 4.2, core tables
enforce a limit on indexes to 191 characters, see:
WordPress/WordPress@b2cf8231

Since `wcmp_visitors_stats.user_cookie` is a `varchar(255)`, some MySQL
configurations using `utf8mb4` charsets will attempt to create an index
of 1020 bytes (4 bytes per character), and will throw the following error:

    Index column size too large. The maximum column size is 767 bytes.

This patch limits the index size of `wcmp_visitors_stats.user_cookie` to
191 characters (764 bytes), and will allow the plugin installation to
proceed under such MySQL configurations.