### PR TITLE
Fix a bug that causes Memory leak in PHP, non-ending unreponsive store and INFINITE PHP LOOP fixes #31

### DIFF
--- a/classes/class-wcmp-product.php
+++ b/classes/class-wcmp-product.php
@@ -74,7 +74,8 @@ class WCMp_Product {
             //add_action('trashed_post', array($this, 'remove_product_from_multiple_seller_mapping'), 10);
             //add_action('untrash_post', array($this, 'restore_multiple_seller_mapping'), 10);
             if (!defined('WCMP_HIDE_MULTIPLE_PRODUCT')) {
-                add_action('woocommerce_shop_loop', array(&$this, 'woocommerce_shop_loop_callback'), 5);
+		//new bug introduced in v3 causes Memory leak in PHP
+                //add_action('woocommerce_shop_loop', array(&$this, 'woocommerce_shop_loop_callback'), 5);
                 add_action('woocommerce_product_query', array(&$this, 'woocommerce_product_query'), 10);
             }
         }


### PR DESCRIPTION
This is a new feature that was introduced in wcmp v3, however, it causes memory leak, non-ending unresponsive store and infinite php loop specially when there are over 1Million products in the database. Disabling this should have minimal effect since wcmp v2 does not implement this anyway.

Commenting the offending code resolves the issue.

The issue was discussed in https://github.com/dualcube/dc-woocommerce-multi-vendor/issues/31