### PR TITLE
Allow editing of draft products and a fix for error in order details

### DIFF
--- a/classes/class-wcmp-ajax.php
+++ b/classes/class-wcmp-ajax.php
@@ -2380,8 +2380,8 @@ class WCMp_Ajax {
                     foreach ($products_array as $product_single) {
                         $row = array();
                         $product = wc_get_product($product_single->ID);
-                        $edit_product_link = '';
-                        if (current_user_can('edit_published_products') && get_wcmp_vendor_settings('is_edit_delete_published_product', 'capabilities', 'product') == 'Enable') {
+                        $edit_product_link = $product->get_permalink(); // changed by Vivek Athalye @vnathalye
+                        if ((current_user_can('edit_published_products') && get_wcmp_vendor_settings('is_edit_delete_published_product', 'capabilities', 'product') == 'Enable') || in_array($product->get_status(), array('draft', 'pending'))) { // changed by Vivek Athalye @vnathalye
                             $edit_product_link = esc_url(wcmp_get_vendor_dashboard_endpoint_url(get_wcmp_vendor_settings('wcmp_add_product_endpoint', 'vendor', 'general', 'add-product'), $product->get_id()));
                         }
                         // Get actions
@@ -2396,7 +2396,7 @@ class WCMp_Ajax {
                             'delete' => '<a class="productDelete" href="' . esc_url(wp_nonce_url(add_query_arg(array('product_id' => $product->get_id()), wcmp_get_vendor_dashboard_endpoint_url(get_wcmp_vendor_settings('wcmp_products_endpoint', 'vendor', 'general', 'products'))), 'wcmp_delete_product')) . '" onclick="' . $onclick . '">' . __('Delete Permanently', 'dc-woocommerce-multi-vendor') . '</a>',
                             'view' => '<a href="' . esc_url($product->get_permalink()) . '" target="_blank">' . $view_title . '</a>',
                         );
-                        if (!current_user_can('edit_published_products') && get_wcmp_vendor_settings('is_edit_delete_published_product', 'capabilities', 'product') != 'Enable') {
+                        if (!current_user_can('edit_published_products') && get_wcmp_vendor_settings('is_edit_delete_published_product', 'capabilities', 'product') != 'Enable' && !in_array($product->get_status(), array('draft', 'pending'))) { // changed by Vivek Athalye @vnathalye
                             unset($actions['edit']);
                             unset($actions['delete']);
                         }

--- a/templates/vendor-dashboard/product-manager/add-product.php
+++ b/templates/vendor-dashboard/product-manager/add-product.php
@@ -22,16 +22,20 @@ if (is_user_logged_in() && is_user_wcmp_vendor($current_vendor_id) && !current_u
     <?php
     return;
 }
-if (is_user_logged_in() && is_user_wcmp_vendor($current_vendor_id) && !current_user_can('edit_published_products') && !empty($pro_id)) {
-    ?>
-    <div class="col-md-12">
-        <div class="panel panel-default">
-            <?php _e('Product has been sent to the admin for review. Once done, the product will be published.', 'dc-woocommerce-multi-vendor'); ?>
-        </div>
-    </div>
-    <?php
-    return;
-}
+
+// changed by Vivek Athalye @vnathalye - start
+// To allow editing of DRAFT products, moved this code below
+// if (is_user_logged_in() && is_user_wcmp_vendor($current_vendor_id) && !current_user_can('edit_published_products') && !empty($pro_id)) {
+//     ? >
+//     <div class="col-md-12">
+//         <div class="panel panel-default">
+//             <?php _e('Product has been sent to the admin for review. Once done, the product will be published.', 'dc-woocommerce-multi-vendor'); ? >
+//         </div>
+//     </div>
+//     <?php
+//     return;
+// }
+// changed by Vivek Athalye @vnathalye - end
 
 $product_id = 0;
 $product = array();
@@ -113,6 +117,32 @@ if (!empty($pro_id)) {
             _e('You do not have enough permission to access this product.', 'dc-woocommerce-multi-vendor');
             return;
         }
+
+        // changed by Vivek Athalye @vnathalye - start
+        // To allow editing of Draft & Pending products, moved this code here and checked the product status
+        // If product status is Pending, show appropriate message
+        // if (is_user_logged_in() && is_user_wcmp_vendor($current_vendor_id) && !current_user_can('edit_published_products') && in_array($product->get_status(), array('pending')) )  {
+        //     ? >
+        //     <div class="col-md-12">
+        //         <div class="panel panel-default">
+        //             <?php _e('Product has been sent to the admin for review. Once done, the product will be published.', 'dc-woocommerce-multi-vendor'); ? >
+        //         </div>
+        //     </div>
+        //     <?php
+        //     return;
+        // }
+        // If product status is not Draft / Pending, show appropriate message
+        if (is_user_logged_in() && is_user_wcmp_vendor($current_vendor_id) && !current_user_can('edit_published_products') && !in_array($product->get_status(), array('draft', 'pending')) )  {
+            ?>
+            <div class="col-md-12">
+                <div class="panel panel-default">
+                    <?php _e('Product is already published. You cannot edit it now.', 'dc-woocommerce-multi-vendor'); ?>
+                </div>
+            </div>
+            <?php
+            return;
+        }
+        // changed by Vivek Athalye @vnathalye - end
 
         $product_type = $product->get_type();
         $title = $product->get_title();

--- a/templates/vendor-dashboard/vendor-orders/vendor-order-details.php
+++ b/templates/vendor-dashboard/vendor-orders/vendor-order-details.php
@@ -15,7 +15,6 @@ if (!defined('ABSPATH')) {
 global $woocommerce, $WCMp;
 $vendor = get_current_vendor();
 $order = wc_get_order($order_id);
-$vendor_shipping_method = get_wcmp_vendor_order_shipping_method($order->get_id(), $vendor->id);
 if (!$order) {
     ?>
     <div class="col-md-12">
@@ -26,6 +25,7 @@ if (!$order) {
     <?php
     return;
 }
+$vendor_shipping_method = get_wcmp_vendor_order_shipping_method($order->get_id(), $vendor->id);
 $vendor_items = get_wcmp_vendor_orders(array('order_id' => $order->get_id(), 'vendor_id' => $vendor->id));
 $vendor_order_amount = get_wcmp_vendor_order_amount(array('order_id' => $order->get_id(), 'vendor_id' => $vendor->id));
 //print_r($vendor_order_amount);die;


### PR DESCRIPTION
Code changes related to:

Allow editing of products that are saved as Draft  …
https://wordpress.org/support/topic/allow-editing-of-products-that-are-saved-as-draft/

Error in vendor order details page  …
https://wc-marketplace.com/support-forum/topic/error-in-vendor-order-details-page/
