### PR TITLE
Fix: Warning "Invalid arguments passed" on Shop page.

### DIFF
--- a/classes/class-wcmp-product.php
+++ b/classes/class-wcmp-product.php
@@ -1807,7 +1807,7 @@ class WCMp_Product {
         return implode( ', ', $termlist );
     }
     
-    public function show_default_product_cats_product_single( $terms = array() ){
+    public function show_default_product_cats_product_single( $terms ){
         global $product;
         if( !is_object( $product )) $product = wc_get_product( get_the_ID() );
         if(is_product() && $product){
@@ -1829,7 +1829,7 @@ class WCMp_Product {
 
             return $links;
         }
-        return $links;
+        return $terms;
     }
     
 }


### PR DESCRIPTION
[Fix] -> $terms getting reset to empty array instead of default  value, removed re-initializing $term. Returning empty array instead of default  value, replaced empty array $links with $terms - default value coming from the filter.
--